### PR TITLE
fix: prevent voting outside allowed time

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -15,6 +15,19 @@ pub mod voting {
         poll_start: u64,
         poll_end: u64,
     ) -> Result<()> {
+        let clock = Clock::get().unwrap();
+        let current_time = clock.unix_timestamp as u64;
+
+        // Check unix timestamp
+        require!(poll_end > 1_000_000_000, ErrorCode::InvalidUnixTimestamp);
+        // Check end time
+        require!(
+            poll_end / 1000 > current_time,
+            ErrorCode::InvalidPollEndTime
+        );
+        // Check start_time < end_time
+        require!(poll_start < poll_end, ErrorCode::InvalidStartTime);
+
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
         poll.description = description;
@@ -129,4 +142,16 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Invalid poll end time")]
+    InvalidPollEndTime,
+    #[msg("Invalid unix timestamp")]
+    InvalidUnixTimestamp,
+    #[msg("Poll inactive")]
+    PollNotActive,
+    #[msg("Invalid start time")]
+    InvalidStartTime,
 }

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -54,6 +54,18 @@ pub mod voting {
     }
 
     pub fn vote(ctx: Context<Vote>, _candidate_name: String, _poll_id: u64) -> Result<()> {
+        let poll = &mut ctx.accounts.poll;
+
+        // Check for voting closed
+        let clock = Clock::get().unwrap();
+        let current_time = clock.unix_timestamp as u64;
+
+        // Check if voting has started
+        require!(poll.poll_start <= current_time, ErrorCode::VotingNotStarted);
+
+        // Check if voting is still open
+        require!(current_time < poll.poll_end / 1000, ErrorCode::VotingClosed);
+
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_votes += 1;
 
@@ -154,4 +166,8 @@ pub enum ErrorCode {
     PollNotActive,
     #[msg("Invalid start time")]
     InvalidStartTime,
+    #[msg("Voting not started")]
+    VotingNotStarted,
+    #[msg("Voting closed")]
+    VotingClosed,
 }

--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -8,12 +8,13 @@ declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 pub mod voting {
     use super::*;
 
-    pub fn initialize_poll(ctx: Context<InitializePoll>, 
-                            poll_id: u64,
-                            description: String,
-                            poll_start: u64,
-                            poll_end: u64) -> Result<()> {
-
+    pub fn initialize_poll(
+        ctx: Context<InitializePoll>,
+        poll_id: u64,
+        description: String,
+        poll_start: u64,
+        poll_end: u64,
+    ) -> Result<()> {
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;
         poll.description = description;
@@ -23,13 +24,19 @@ pub mod voting {
         Ok(())
     }
 
-    pub fn initialize_candidate(ctx: Context<InitializeCandidate>, 
-                                candidate_name: String,
-                                _poll_id: u64
-                            ) -> Result<()> {
+    pub fn initialize_candidate(
+        ctx: Context<InitializeCandidate>,
+        candidate_name: String,
+        _poll_id: u64,
+    ) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
+        let poll_account = &mut ctx.accounts.poll;
+
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
+
+        // Increment candidate amount
+        poll_account.candidate_amount += 1;
         Ok(())
     }
 
@@ -41,7 +48,6 @@ pub mod voting {
         msg!("Votes: {}", candidate.candidate_votes);
         Ok(())
     }
-
 }
 
 #[derive(Accounts)]
@@ -65,7 +71,6 @@ pub struct Vote<'info> {
 
     pub system_program: Program<'info, System>,
 }
-
 
 #[derive(Accounts)]
 #[instruction(candidate_name: String, poll_id: u64)]

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -69,6 +69,15 @@ describe("Voting", () => {
     console.log(blueCandidate);
     expect(blueCandidate.candidateVotes.toNumber()).toBe(0);
     expect(blueCandidate.candidateName).toBe("Blue");
+
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+
+    // Check the candidate amount
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+    expect(poll.candidateAmount).toBe(2);
   });
 
   it("vote candidates", async () => {

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -112,4 +112,18 @@ describe("Voting", () => {
     expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
     expect(blueCandidate.candidateName).toBe("Blue");
   });
+
+  // Fails to create poll
+  it("fails to initialize a poll due to invalid poll_end timestamp", async () => {
+    await expect(
+      votingProgram.methods
+        .initializePoll(
+          new anchor.BN(2),
+          "Is Solana the fastest blockchain?",
+          new anchor.BN(100),
+          new anchor.BN(Math.floor(Date.now() / 1000) - 100) // Invalid poll_end 
+        )
+        .rpc()
+    ).rejects.toThrow(/InvalidUnixTimestamp/);
+  });
 });

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -80,6 +80,24 @@ describe("Voting", () => {
     expect(poll.candidateAmount).toBe(2);
   });
 
+  // Check voting start
+  it("fails to vote because voting has not started", async () => {
+    await expect(
+      votingProgram.methods
+        .vote("Pink", new anchor.BN(1))
+        .rpc()
+    ).rejects.toThrow(/VotingNotStarted/);
+  });
+
+  // Check voting end
+  it("fails to vote because voting has ended", async () => {
+    await expect(
+      votingProgram.methods
+        .vote("Pink", new anchor.BN(1))
+        .rpc()
+    ).rejects.toThrow(/VotingClosed/);
+  });
+
   it("vote candidates", async () => {
     await votingProgram.methods.vote(
       "Pink",


### PR DESCRIPTION
Fixes #3 

### Changes Made  
- Updated `ErrorCode` enum to handle errors
- Added validation to ensure voting happens only within the poll’s start and end time.
- Added a **bankrun test** to fail voting when the poll hasn't started or has ended.
- Formatted the program with Prettier.

Email: priyanshpatel18@gmail.com