### PR TITLE
Validate poll_start & poll_end Timestamp During Poll Initialization

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -4,6 +4,15 @@ use anchor_lang::prelude::*;
 
 declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 
+// poll validation error 
+#[error_code]
+pub enum PollError {
+    #[msg("Poll end time must be in the future")]
+    InvalidPollEndTime,
+    #[msg("Invalid Unix timestamp")]
+    InvalidTimestamp,
+}
+
 #[program]
 pub mod voting {
     use super::*;
@@ -13,6 +22,15 @@ pub mod voting {
                             description: String,
                             poll_start: u64,
                             poll_end: u64) -> Result<()> {
+        //current time
+        let clock = Clock::get()?;
+        let current_time = clock.unix_timestamp as u64;
+
+        //validate timestamp
+        require!(poll_end > 0, PollError::InvalidTimestamp);
+
+        // poll end time validate
+        require!(poll_end > current_time, PollError::InvalidPollEndTime);
 
         let poll = &mut ctx.accounts.poll;
         poll.poll_id = poll_id;

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -2,6 +2,7 @@ import * as anchor from "@coral-xyz/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { BankrunProvider, startAnchor } from "anchor-bankrun";
 import { Voting } from "../target/types/voting";
+import { expect } from "@jest/globals";
 
 const IDL = require("../target/idl/voting.json");
 const PROGRAM_ID = new PublicKey(IDL.address);
@@ -20,12 +21,15 @@ describe("Voting", () => {
     );
   });
 
-  it("initializes a poll", async () => {
+  it("initializes a poll with valid end time", async () => {
+    const currentTime = Math.floor(Date.now() / 1000);
+    const futureTime = currentTime + 3600; // 1 hour in the future
+
     await votingProgram.methods.initializePoll(
       new anchor.BN(1),
       "What is your favorite color?",
-      new anchor.BN(100),
-      new anchor.BN(1739370789),
+      new anchor.BN(currentTime),
+      new anchor.BN(futureTime),
     ).rpc();
 
     const [pollAddress] = PublicKey.findProgramAddressSync(
@@ -35,14 +39,54 @@ describe("Voting", () => {
 
     const poll = await votingProgram.account.poll.fetch(pollAddress);
 
-    console.log(poll);
+    expect(poll.pollId.toNumber()).toBe(1);
+    expect(poll.description).toBe("What is your favorite color?");
+    expect(poll.pollStart.toNumber()).toBe(currentTime);
+    expect(poll.pollEnd.toNumber()).toBe(futureTime);
+  });
 
+  it("fails to initialize poll with past end time", async () => {
+    const currentTime = Math.floor(Date.now() / 1000);
+    const pastTime = currentTime - 3600; // 1 hour in the past
+
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(2),
+        "Past poll",
+        new anchor.BN(currentTime),
+        new anchor.BN(pastTime),
+      ).rpc();
+      // If we reach here, the test should fail
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error.toString()).toContain("Poll end time must be in the future");
+    }
+  });
+
+  it("fails to initialize poll with invalid timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(3),
+        "Invalid timestamp poll",
+        new anchor.BN(100),
+        new anchor.BN(0), // Invalid timestamp
+      ).rpc();
+      // If we reach here, the test should fail
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error.toString()).toContain("Invalid Unix timestamp");
+    }
+
+    console.log(poll);
     expect(poll.pollId.toNumber()).toBe(1);
     expect(poll.description).toBe("What is your favorite color?");
     expect(poll.pollStart.toNumber()).toBe(100);
+    expect(poll.candidateAmount.toNumber()).toBe(0);
+    expect(poll.totalVotes.toNumber()).toBe(0);
+
   });
 
-  it("initializes candidates", async () => {
+  it("initializes candidates and updates poll", async () => {
     await votingProgram.methods.initializeCandidate(
       "Pink",
       new anchor.BN(1),
@@ -52,55 +96,74 @@ describe("Voting", () => {
       new anchor.BN(1),
     ).rpc();
 
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+    expect(poll.candidateAmount.toNumber()).toBe(2);
+
     const [pinkAddress] = PublicKey.findProgramAddressSync(
       [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Pink")],
       votingProgram.programId,
     );
     const pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
-    console.log(pinkCandidate);
     expect(pinkCandidate.candidateVotes.toNumber()).toBe(0);
-    expect(pinkCandidate.candidateName).toBe("Pink");
 
     const [blueAddress] = PublicKey.findProgramAddressSync(
       [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Blue")],
       votingProgram.programId,
     );
     const blueCandidate = await votingProgram.account.candidate.fetch(blueAddress);
-    console.log(blueCandidate);
     expect(blueCandidate.candidateVotes.toNumber()).toBe(0);
-    expect(blueCandidate.candidateName).toBe("Blue");
   });
 
-  it("vote candidates", async () => {
-    await votingProgram.methods.vote(
-      "Pink",
-      new anchor.BN(1),
-    ).rpc();
+  it("votes for candidates and updates poll total votes", async () => {
+    await votingProgram.methods.vote("Pink", new anchor.BN(1)).rpc();
+    await votingProgram.methods.vote("Blue", new anchor.BN(1)).rpc();
+    await votingProgram.methods.vote("Pink", new anchor.BN(1)).rpc();
+
+    const [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+    expect(poll.totalVotes.toNumber()).toBe(3);
+
+    // Verify first vote was counted
+    let pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
+    expect(pinkCandidate.candidateVotes.toNumber()).toBe(1);
+
+    const pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
+    expect(pinkCandidate.candidateVotes.toNumber()).toBe(2);
+
+    // Second vote should fail
+    try {
+      await votingProgram.methods.vote(
+        "Pink",
+        new anchor.BN(1),
+      ).rpc();
+      throw new Error("Expected second vote to fail");
+    } catch (error) {
+      expect(error.message).toContain("Voter has already cast a vote in this poll");
+    }
+
+    // Verify vote count hasn't changed
+    pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
+    expect(pinkCandidate.candidateVotes.toNumber()).toBe(1);
+
+    // Different user can still vote for Blue
+    const [blueAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Blue")],
+      votingProgram.programId,
+    );
+
     await votingProgram.methods.vote(
       "Blue",
       new anchor.BN(1),
     ).rpc();
-    await votingProgram.methods.vote(
-      "Pink",
-      new anchor.BN(1),
-    ).rpc();
 
-    const [pinkAddress] = PublicKey.findProgramAddressSync(
-      [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Pink")],
-      votingProgram.programId,
-    );
-    const pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
-    console.log(pinkCandidate);
-    expect(pinkCandidate.candidateVotes.toNumber()).toBe(2);
-    expect(pinkCandidate.candidateName).toBe("Pink");
-
-    const [blueAddress] = PublicKey.findProgramAddressSync(
-      [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Blue")],
-      votingProgram.programId,
-    );
     const blueCandidate = await votingProgram.account.candidate.fetch(blueAddress);
-    console.log(blueCandidate);
     expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
-    expect(blueCandidate.candidateName).toBe("Blue");
   });
 });


### PR DESCRIPTION
Added validation in the poll initialization to ensure poll_end is after the current time.. 
 This pull request was created for https://app.gib.work/bounties/05c78859-768e-4940-aa0c-2a4d021cf071 in an attempt to solve a bounty #2 . Payment for the bounty is immediately sent to the contributor after merge.